### PR TITLE
feat(deleteButton): add deleteButton in OrderDetail

### DIFF
--- a/src/app/components/DeleteOrderStatementButton.tsx
+++ b/src/app/components/DeleteOrderStatementButton.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { deleteOrderAction } from "@/lib/action/order";
+import { OrderDeleteState } from "@/lib/schema/order/order";
+import { useActionState, useEffect, useRef } from "react";
+
+interface Props {
+    orderId: number;
+    orderStatementId: number;
+}
+
+const initialState: OrderDeleteState = { success: false, error: undefined };
+
+export default function DeleteOrderStatementButton({
+    orderId,
+    orderStatementId,
+}: Props) {
+    const [state, formAction, isPending] = useActionState(
+        (prevState: OrderDeleteState) => 
+            deleteOrderAction(orderId, orderStatementId, prevState),
+        initialState
+    );
+
+    const handleClick = (e: React.MouseEvent) => {
+        if (!confirm('해당 주문서를 삭제하시겠습니까?\n이 작업은 되돌릴 수 없습니다.')) {
+            e.preventDefault();
+        }
+    };
+
+    return (
+        <form action={formAction} className="inline">
+            <button
+                type="submit"
+                onClick={handleClick}
+                disabled={isPending}
+                className="px-3 py-1.5 text-sm font-medium text-red-600 
+                         bg-red-50 rounded hover:bg-red-100 
+                         disabled:opacity-50 disabled:cursor-not-allowed
+                         transition-colors"
+            >
+                {isPending ? '처리 중...' : '삭제'}
+            </button>
+
+            {/* 실패 시에만 에러 표시 (성공 시에는 리다이렉트되므로 불필요) */}
+            {state?.error && (
+                <div 
+                    role="alert"
+                    className="mt-2 p-2 text-xs text-red-700 bg-red-50 
+                             border border-red-200 rounded"
+                >
+                    {state.error}
+                </div>
+            )}
+        </form>
+    );
+}

--- a/src/app/components/OrderDetail.tsx
+++ b/src/app/components/OrderDetail.tsx
@@ -3,6 +3,7 @@
 import { OrderQueryRes } from '@/lib/schema/order/order';
 import { getProductImageSrc } from '@/lib/util/image-load';
 import Image from 'next/image';
+import DeleteOrderStatementButton from './DeleteOrderStatementButton';
 
 interface Props {
     order: OrderQueryRes;
@@ -20,7 +21,14 @@ export default function OrderDetail({ order }: Props) {
                 <h1 className="text-2xl font-bold">주문 #{order.id} 상세</h1>
 
                 {order.orderStatements.map((statement) => (
-                    <div key={statement.id} className="border rounded-lg p-4 bg-white">
+                    <div key={statement.id} className="border rounded-lg p-4 bg-white relative">
+                        <div className="absolute top-3 right-3">
+                            <DeleteOrderStatementButton
+                                orderId={order.id}
+                                orderStatementId={statement.id}
+                            />
+                        </div>
+                        
                         <div className="mb-4 pb-4 border-b">
                             <p className="text-sm text-gray-600">
                                 <span className="font-medium">배송지:</span> {statement.address}

--- a/src/lib/action/order.ts
+++ b/src/lib/action/order.ts
@@ -4,7 +4,6 @@ import { revalidatePath } from "next/cache";
 import { OrderCreateReq, OrderCreateState, OrderDeleteState, OrderUpdateReq, OrderUpdateState } from "../schema/order/order";
 import { createOrder, deleteOrder, updateOrder } from "../service/order";
 import { redirect } from "next/navigation";
-import { success } from "zod";
 
 export async function createOrderAction(prevState: OrderCreateState, formData: FormData) {
     const email = formData.get('email') as string;
@@ -112,9 +111,12 @@ export async function updateOrderAction(id: number, prevState: OrderUpdateState,
     redirect(`/order/${id}`);
 }
 
-export async function deleteOrderAction(id: number, prevState: OrderDeleteState) {
+export async function deleteOrderAction(
+    orderId: number, 
+    orderStatementId: number, 
+    prevState: OrderDeleteState) {
     try {
-        await deleteOrder(id);
+        await deleteOrder(orderId, orderStatementId);
     } catch (error) {
         return {
             ...prevState,
@@ -122,7 +124,7 @@ export async function deleteOrderAction(id: number, prevState: OrderDeleteState)
             error: error instanceof Error ? error.message : "삭제 중 오류가 발생했습니다.",
         }
     }
-    revalidatePath("/order");
-    revalidatePath(`/order/${id}`);
-    redirect("/order");
+    revalidatePath("/orders");
+    revalidatePath(`/orders/${orderId}`);
+    redirect("/orders");
 }

--- a/src/lib/service/order.ts
+++ b/src/lib/service/order.ts
@@ -130,8 +130,8 @@ export async function updateOrder(id: number, input: OrderUpdateReq) {
     }
 }
 
-export async function deleteOrder(id: number) {
-    const res = await fetch(`${API_URL}/order/${id}`, {
+export async function deleteOrder(orderId: number, orderStatementId: number) {
+    const res = await fetch(`${API_URL}/order/${orderId}/statement/${orderStatementId}`, {
         method: 'DELETE',
     });
 


### PR DESCRIPTION
## 📌 과제 설명 
주문서 삭제 구현

## 👩‍💻 요구 사항과 구현 내용 
1. 주문서 삭제 API Backend와 맞게 수정
2. 주문서 삭제 API를 적용한 삭제 버튼을 주문 상세 조회 페이지에 추가