### PR TITLE
fix : fix unloaded created statement and reshape deleteButton

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,11 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
+    "clsx": "^2.1.1",
     "next": "16.2.0",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "tailwind-merge": "^3.5.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       next:
         specifier: 16.2.0
         version: 16.2.0(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -17,6 +20,9 @@ importers:
       react-dom:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
+      tailwind-merge:
+        specifier: ^3.5.0
+        version: 3.5.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -1187,6 +1193,10 @@ packages:
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
@@ -2662,6 +2672,9 @@ packages:
     resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
+  tailwind-merge@3.5.0:
+    resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
+
   tailwindcss@4.2.2:
     resolution: {integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==}
 
@@ -4068,6 +4081,8 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+
+  clsx@2.1.1: {}
 
   co@4.6.0: {}
 
@@ -5897,6 +5912,8 @@ snapshots:
   synckit@0.11.12:
     dependencies:
       '@pkgr/core': 0.2.9
+
+  tailwind-merge@3.5.0: {}
 
   tailwindcss@4.2.2: {}
 

--- a/src/app/components/DeleteOrderStatementButton.tsx
+++ b/src/app/components/DeleteOrderStatementButton.tsx
@@ -2,6 +2,7 @@
 
 import { deleteOrderAction } from "@/lib/action/order";
 import { OrderDeleteState } from "@/lib/schema/order/order";
+import { cn } from "@/lib/util/css-load";
 import { useActionState, useEffect, useRef } from "react";
 
 interface Props {
@@ -16,7 +17,7 @@ export default function DeleteOrderStatementButton({
     orderStatementId,
 }: Props) {
     const [state, formAction, isPending] = useActionState(
-        (prevState: OrderDeleteState) => 
+        (prevState: OrderDeleteState) =>
             deleteOrderAction(orderId, orderStatementId, prevState),
         initialState
     );
@@ -33,17 +34,19 @@ export default function DeleteOrderStatementButton({
                 type="submit"
                 onClick={handleClick}
                 disabled={isPending}
-                className="px-3 py-1.5 text-sm font-medium text-red-600 
-                         bg-red-50 rounded hover:bg-red-100 
-                         disabled:opacity-50 disabled:cursor-not-allowed
-                         transition-colors"
+                className={cn(
+                    "px-3 py-1.5 text-sm font-medium text-red-600",
+                    "bg-red-50 rounded hover:bg-red-100",
+                    "disabled:opacity-50 disabled:cursor-not-allowed",
+                    "transition-colors"
+                )}
             >
                 {isPending ? '처리 중...' : '삭제'}
             </button>
 
             {/* 실패 시에만 에러 표시 (성공 시에는 리다이렉트되므로 불필요) */}
             {state?.error && (
-                <div 
+                <div
                     role="alert"
                     className="mt-2 p-2 text-xs text-red-700 bg-red-50 
                              border border-red-200 rounded"

--- a/src/lib/action/order.ts
+++ b/src/lib/action/order.ts
@@ -80,6 +80,7 @@ export async function createOrderAction(prevState: OrderCreateState, formData: F
     }
 
     revalidatePath('/orders');
+    revalidatePath(`/orders/${result.data!.orderId}`);
     redirect(`/orders/${result.data!.orderId}`);
 }
 

--- a/src/lib/util/css-load.ts
+++ b/src/lib/util/css-load.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
## 📌 과제 설명 
주문서 생성 시 같은 주문에서 주문서가 생성되는 경우 아래 두 문제의 버그가 있었고 이를 해결함
1. 주문서가 갱신된 주문으로 전달되지 않음
2. deleteButton 렌더링에 문제가 있음

## 👩‍💻 요구 사항과 구현 내용 
1. 주문를 생성할 때 해당 주문 조회의 캐시를 무효화 시키고 다시 서버로부터 조회받도록 변경
2. deleteButton의 css 정의를 개행 문자 없이 표현하도록 수정