### PR TITLE
11 feat add form to update orderstatement

### DIFF
--- a/src/app/components/OrderDetail.tsx
+++ b/src/app/components/OrderDetail.tsx
@@ -31,14 +31,14 @@ export default function OrderDetail({ order }: Props) {
                             >
                                 수정
                             </Link>
-                            
+
                             {/* 기존 삭제 버튼 */}
                             <DeleteOrderStatementButton
                                 orderId={order.id}
                                 orderStatementId={statement.id}
                             />
                         </div>
-                        
+
                         <div className="mb-4 pb-4 border-b">
                             <p className="text-sm text-gray-600">
                                 <span className="font-medium">배송지:</span> {statement.address}
@@ -82,6 +82,14 @@ export default function OrderDetail({ order }: Props) {
                         </div>
                     </div>
                 ))}
+                <div className="pt-4 border-t">
+                    <Link
+                        href="/orders"
+                        className="inline-flex items-center gap-2 text-sm text-gray-600 hover:text-blue-600 transition"
+                    >
+                        ← 주문 목록으로 돌아가기
+                    </Link>
+                </div>
             </div>
 
             <aside className="lg:col-span-1">

--- a/src/app/components/OrderDetail.tsx
+++ b/src/app/components/OrderDetail.tsx
@@ -4,6 +4,7 @@ import { OrderQueryRes } from '@/lib/schema/order/order';
 import { getProductImageSrc } from '@/lib/util/image-load';
 import Image from 'next/image';
 import DeleteOrderStatementButton from './DeleteOrderStatementButton';
+import Link from 'next/link';
 
 interface Props {
     order: OrderQueryRes;
@@ -22,7 +23,16 @@ export default function OrderDetail({ order }: Props) {
 
                 {order.orderStatements.map((statement) => (
                     <div key={statement.id} className="border rounded-lg p-4 bg-white relative">
-                        <div className="absolute top-3 right-3">
+                        <div className="absolute top-3 right-3 flex gap-2">
+                            {/* 수정 버튼 */}
+                            <Link
+                                href={`/orders/${order.id}/statements/${statement.id}/edit`}
+                                className="px-3 py-1.5 text-sm font-medium text-blue-600 bg-blue-50 rounded-lg hover:bg-blue-100 transition border border-blue-200"
+                            >
+                                수정
+                            </Link>
+                            
+                            {/* 기존 삭제 버튼 */}
                             <DeleteOrderStatementButton
                                 orderId={order.id}
                                 orderStatementId={statement.id}

--- a/src/app/components/UpdateOrderForm.tsx
+++ b/src/app/components/UpdateOrderForm.tsx
@@ -1,0 +1,166 @@
+// src/components/order/OrderUpdate.tsx
+'use client';
+
+import { useActionState, useRef, useEffect } from 'react';
+import { updateOrderAction } from '@/lib/action/order';
+import { OrderUpdateState, OrderQueryRes } from '@/lib/schema/order/order';
+import ProductSelector from './ProductSelector';
+import { ProductItem } from '@/lib/schema/product';
+
+interface Props {
+  order: OrderQueryRes;
+  initialProducts: ProductItem[];
+  targetStatementId: number; // 수정할 주문서 (Statement) 의 ID
+}
+
+const initialState: OrderUpdateState = {
+  success: false,
+  error: undefined,
+  fieldErrors: undefined,
+};
+
+export default function UpdateOrderForm({ order, initialProducts, targetStatementId }: Props) {
+  // 수정 대상 주문서 (Statement) 찾기
+  const targetStatement = order.orderStatements.find(s => s.id === targetStatementId);
+
+  // 데이터가 없으면 컴포넌트 렌더링 중단 (페이지 레벨에서 처리하는 것이 더 좋지만 안전장치 추가)
+  if (!targetStatement) {
+    return <div className="p-4 text-red-500">수정할 주문서 정보를 찾을 수 없습니다.</div>;
+  }
+
+  const [state, formAction, isPending] = useActionState(
+    (prevState: OrderUpdateState, formData: FormData) => 
+      updateOrderAction(order.id, targetStatementId, prevState, formData),
+    initialState
+  );
+
+  const selectedItemsRef = useRef<Array<{ productId: number; quantity: number }>>([]);
+
+  // 초기 선택된 상품 데이터를 Map 형태로 변환하여 ProductSelector 에 전달
+  const initialSelectedItems = targetStatement.orderItems.map(item => ({
+    productId: item.productItem.productId,
+    quantity: item.quantity
+  }));
+
+  const handleSelectedItemsChange = (items: Array<{ productId: number; quantity: number }>) => {
+    selectedItemsRef.current = items;
+  };
+
+  const handleSubmit = (e: React.SubmitEvent<HTMLFormElement>) => {
+    // 클라이언트 사이드 최종 검증: 상품이 하나도 선택되지 않은 경우
+    if (selectedItemsRef.current.length === 0) {
+      e.preventDefault();
+      alert('최소 하나 이상의 제품을 선택해주세요');
+      return;
+    }
+    // hidden input 에 선택된 상품 데이터 주입
+    const hiddenInput = document.querySelector('input[name="orderItems"]') as HTMLInputElement;
+    if (hiddenInput) {
+      hiddenInput.value = JSON.stringify(selectedItemsRef.current);
+    }
+  };
+
+  return (
+    <main className="container mx-auto px-4 py-8 max-w-2xl">
+      <h1 className="text-2xl font-bold mb-6">주문 수정하기</h1>
+
+      <form 
+        action={formAction} 
+        onSubmit={handleSubmit}
+        className="space-y-6 bg-white p-6 rounded-lg shadow"
+      >
+        {/* ✅ 이메일 (Read-only) */}
+        <div>
+          <label className="block text-sm font-medium mb-1 text-gray-700">
+            이메일
+          </label>
+          <div className="w-full px-3 py-2 bg-gray-100 border border-gray-200 rounded-lg text-gray-600">
+            {order.email}
+          </div>
+          <p className="text-xs text-gray-400 mt-1">이메일은 주문 생성 후 수정할 수 없습니다.</p>
+          {/* 서버 전송용 hidden input (필요시) */}
+          <input type="hidden" name="email" value={order.email} />
+        </div>
+
+        {/* 주소 (기존 데이터로 pre-fill) */}
+        <div>
+          <label htmlFor="address" className="block text-sm font-medium mb-1">
+            주소 *
+          </label>
+          <input
+            type="text"
+            id="address"
+            name="address"
+            defaultValue={targetStatement.address}
+            className="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500"
+            placeholder="서울시 강남구 ..."
+            required
+          />
+          {state.fieldErrors?.address && (
+            <p className="text-red-500 text-sm mt-1">{state.fieldErrors.address}</p>
+          )}
+        </div>
+
+        {/* 우편번호 (기존 데이터로 pre-fill) */}
+        <div>
+          <label htmlFor="zipCode" className="block text-sm font-medium mb-1">
+            우편번호 *
+          </label>
+          <input
+            type="text"
+            id="zipCode"
+            name="zipCode"
+            defaultValue={targetStatement.zipCode}
+            className="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500"
+            placeholder="06000"
+            pattern="\d{5}"
+            maxLength={5}
+            required
+          />
+          {state.fieldErrors?.zipCode && (
+            <p className="text-red-500 text-sm mt-1">{state.fieldErrors.zipCode}</p>
+          )}
+        </div>
+
+        {/* ✅ 제품 선택 컴포넌트 (초기값 전달) */}
+        <div className="border-t pt-6">
+          <ProductSelector 
+            initialProducts={initialProducts}
+            onSelectedItemsChange={handleSelectedItemsChange}
+            initialSelectedItems={initialSelectedItems} // 👈 기존 주문 항목을 초기값으로 설정
+          />
+          {state.fieldErrors?.orderItems && (
+            <p className="text-red-500 text-sm mt-2">{state.fieldErrors.orderItems}</p>
+          )}
+        </div>
+
+        <input type="hidden" name="orderItems" defaultValue={JSON.stringify(initialSelectedItems)} />
+
+        {/* 전체 에러 메시지 */}
+        {state.error && !state.fieldErrors && (
+          <div className="bg-red-50 text-red-600 p-4 rounded-lg">
+            {state.error}
+          </div>
+        )}
+
+        {/* 제출 버튼 */}
+        <div className="flex gap-3">
+          <button
+            type="submit"
+            disabled={isPending}
+            className="flex-1 bg-blue-600 text-white py-3 rounded-lg hover:bg-blue-700 transition disabled:opacity-50 font-medium"
+          >
+            {isPending ? '수정 중...' : '주문 수정하기'}
+          </button>
+          <button
+            type="button"
+            onClick={() => window.history.back()}
+            className="px-6 py-3 border border-gray-300 rounded-lg hover:bg-gray-50 transition text-gray-700 font-medium"
+          >
+            취소
+          </button>
+        </div>
+      </form>
+    </main>
+  );
+}

--- a/src/app/orders/[orderId]/page.tsx
+++ b/src/app/orders/[orderId]/page.tsx
@@ -5,19 +5,19 @@ import { getOrder } from '@/lib/service/order';
 import { notFound } from 'next/navigation';
 
 interface Props {
-  params: Promise<{ id: string }>;
+  params: Promise<{ orderId: string }>;
 }
 
 export default async function OrderDetailPage({ params }: Props) {
-  const { id } = await params;
-  const orderId = parseInt(id, 10);
+  const { orderId } = await params;
+  const orderIdNum = parseInt(orderId, 10);
   
-  if (isNaN(orderId)) {
+  if (isNaN(orderIdNum)) {
     notFound();
   }
 
   try {
-    const order = await getOrder(orderId);
+    const order = await getOrder(orderIdNum);
     
     return (
       <main className="container mx-auto px-4 py-8">

--- a/src/app/orders/[orderId]/statements/[statementId]/edit/page.tsx
+++ b/src/app/orders/[orderId]/statements/[statementId]/edit/page.tsx
@@ -1,0 +1,50 @@
+import OrderDetail from '@/app/components/OrderDetail';
+import UpdateOrderForm from '@/app/components/UpdateOrderForm';
+import { getOrder } from '@/lib/service/order';
+import { getProductList } from '@/lib/service/product';
+import { notFound } from 'next/navigation';
+
+interface Props {
+  params: Promise<{ 
+    orderId: string; 
+    statementId: string; 
+  }>;
+}
+
+export default async function StatementEditPage({ params }: Props) {
+  const { orderId, statementId } = await params;
+  
+  const orderIdNum = parseInt(orderId, 10);
+  const statementIdNum = parseInt(statementId, 10);
+    
+  if (isNaN(orderIdNum) || isNaN(statementIdNum)) {
+    notFound();
+  }
+
+  try {
+    // 1. 주문 상세 데이터 조회
+    const order = await getOrder(orderIdNum);
+    
+    // 2. 요청한 statementId 가 해당 주문에 실제로 존재하는지 검증
+    const targetStatement = order.orderStatements.find(s => s.id === statementIdNum);
+    if (!targetStatement) {
+      notFound();
+    }
+    
+    // 3. 상품 목록 조회
+    const products = await getProductList();
+    
+    return (
+      <UpdateOrderForm
+        order={order} 
+        initialProducts={products.items} 
+        targetStatementId={statementIdNum}
+      />
+    );
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Order Not Found') {
+      notFound();
+    }
+    throw error;
+  }
+}

--- a/src/lib/action/order.ts
+++ b/src/lib/action/order.ts
@@ -84,7 +84,11 @@ export async function createOrderAction(prevState: OrderCreateState, formData: F
     redirect(`/orders/${result.data!.orderId}`);
 }
 
-export async function updateOrderAction(id: number, prevState: OrderUpdateState, formData: FormData) {
+export async function updateOrderAction(
+    orderId: number,
+    orderStatementId: number,
+    prevState: OrderUpdateState,
+    formData: FormData) {
     const email = formData.get('email') as string;
     const address = formData.get('address') as string;
     const zipCode = formData.get('zipCode') as string;
@@ -103,9 +107,14 @@ export async function updateOrderAction(id: number, prevState: OrderUpdateState,
         };
     }
 
+    for (const item of orderItems) {
+        if (!item.productId || item.productId <= 0) return { ...prevState, success: false, error: '유효하지 않은 상품 ID 가 포함되었습니다' };
+        if (!item.quantity || item.quantity <= 0) return { ...prevState, success: false, error: '상품 수량은 1 개 이상이어야 합니다' };
+    }
+
     const input = {
         email,
-        orderStatements: {
+        orderStatement: {
             address,
             zipCode,
             orderItems
@@ -115,13 +124,13 @@ export async function updateOrderAction(id: number, prevState: OrderUpdateState,
     let result;
 
     try {
-        result = await updateOrder(id, input);
+        result = await updateOrder(orderId, orderStatementId, input);
 
         if (!result.success) {
             return {
                 ...prevState,
                 error: result.error,
-                fieldErrors: result.fieldErrors,
+                fieldErrors: result.fieldErrors ?? {},
                 success: false
             };
         }
@@ -133,9 +142,9 @@ export async function updateOrderAction(id: number, prevState: OrderUpdateState,
         };
     }
 
-    revalidatePath('/order');
-    revalidatePath(`/order/${id}`);
-    redirect(`/order/${id}`);
+    revalidatePath('/orders');
+    revalidatePath(`/orders/${orderId}`);
+    redirect(`/orders/${orderId}`);
 }
 
 export async function deleteOrderAction(

--- a/src/lib/schema/order/order.ts
+++ b/src/lib/schema/order/order.ts
@@ -20,9 +20,16 @@ export const orderQueryResSchema = z.object({
     orderStatements: z.array(orderStatementResSchema)
 });
 
-export const orderUpdateReqSchema = orderCreateReqSchema;
+export const orderUpdateReqSchema = z.object({
+    email: z.email(),
+    orderStatement: orderStatementReqSchema
+});
 
-export const orderUpdateResSchema = orderCreateResSchema;
+export const orderUpdateResSchema = z.object({
+    orderStatementId: z.number().int().positive(),
+    email: z.email(),
+    createdAt: z.coerce.date()
+});
 
 export type OrderCreateReq = z.infer<typeof orderCreateReqSchema>;
 export type OrderCreateRes = z.infer<typeof orderCreateResSchema>;

--- a/src/lib/service/order.ts
+++ b/src/lib/service/order.ts
@@ -87,7 +87,7 @@ export async function createOrder(input: OrderCreateReq) {
     }
 }
 
-export async function updateOrder(id: number, input: OrderUpdateReq) {
+export async function updateOrder(orderId: number, orderStatementId: number, input: OrderUpdateReq) {
     const validated = orderUpdateReqSchema.safeParse(input);
 
     if (!validated.success) {
@@ -107,24 +107,22 @@ export async function updateOrder(id: number, input: OrderUpdateReq) {
     }
 
     try {
-        const res = await fetch(`${API_URL}/order/${id}`, {
+        const res = await fetch(`${API_URL}/order/${orderId}/statement/${orderStatementId}`, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(validated.data)
         });
 
         if (!res.ok) {
-            throw new Error(`Failed to update order: ${res.status}`);
+            const errorData = await res.json().catch(() => ({}));
+            throw new Error(errorData.message || `Failed to update order: ${res.status}`);
         }
 
         const response = await res.json();
 
-        const apiResponse = orderCreateResSchema.parse(response);
-
-        if (!apiResponse.success) {
-            throw new Error(apiResponse.message);
-        }
-        return { success: true, data: apiResponse.data };
+        const apiResponse = orderUpdateResSchema.parse(response);
+        
+        return { success: true, data: apiResponse };
 
     } catch (error) {
         return {


### PR DESCRIPTION
## 📌 과제 설명 
OrderUpdateForm 및 그와 연결된 Order Update Logic을 백엔드와 연결,
주문 상세 페이지에서 주문 리스트 페이지로 넘어가는 링크 버튼 추가

## 👩‍💻 요구 사항과 구현 내용 
OrderUpdateForm 및 그와 연결된 Order Update Logic을 백엔드와 연결
1. OrderUpdate API (server layer) 업데이트
2. OrderUpdate Dto 업데이트
3. OrderUpdate Action 업데이트
4. OrderUpdate Form 생성
5. OrderUpdate page 위치 변경 및 업데이트 로직을 위한 데이터 fetch 추가

주문 상세 페이지에서 주문 리스트 페이지로 넘어가는 링크 버튼 추가